### PR TITLE
feat: [ANA-53] Logging execution time and app version

### DIFF
--- a/app/controllers/async_request/jobs_controller.rb
+++ b/app/controllers/async_request/jobs_controller.rb
@@ -15,13 +15,21 @@ module AsyncRequest
     end
 
     def render_finished_job(job)
+      log_execution_time(job)
       render json: JSON.parse(job.response), status: job.status_code
     end
 
     def log_request
       Rails.logger.info do
         "Request for \"utility_code\": \"#{utility_code_header}\"\n" \
-        "Request for \"channel\": \"#{channel_header}\""
+        "Request for \"channel\": \"#{channel_header}\"\n" \
+        "Request for \"app_version\": \"#{app_version_header}\""
+      end
+    end
+
+    def log_execution_time(job)
+      Rails.logger.info do
+        "Total job execution time: #{job.execution_time}ms"
       end
     end
 
@@ -31,6 +39,10 @@ module AsyncRequest
 
     def channel_header
       @channel_header ||= request.headers['Channel']
+    end
+
+    def app_version_header
+      @app_version_header ||= request.headers['APP-VERSION']
     end
   end
 end

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -8,12 +8,12 @@ module AsyncRequest
     end
 
     def processing!
-      Rails.logger.info("Processing #{worker} job with id=#{id}")
+      Rails.logger.info("Processing #{worker} job with id=#{uid}")
       super
     end
 
     def successfully_processed!(response, status_code)
-      Rails.logger.info("Processing finished successfully for #{worker} job with id=#{id}")
+      Rails.logger.info("Processing finished successfully for #{worker} job with id=#{uid}")
       update_attributes!(
         status: :processed,
         status_code: map_status_code(status_code),
@@ -22,11 +22,15 @@ module AsyncRequest
     end
 
     def finished_with_errors!(error)
-      log_message = "Processing failed for #{worker} job with id=#{id}"
+      log_message = "Processing failed for #{worker} job with id=#{uid}"
       Rails.logger.info(log_message)
       Rails.logger.error "#{error.inspect} \n #{error.backtrace.join("\n")}"
       Rollbar.error(error, log_message, params: filtered_params(params))
       update_attributes!(status: :failed, status_code: 500, response: error_response(error))
+    end
+
+    def execution_time
+      1000 * (updated_at - created_at).to_i
     end
 
     private

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -29,6 +29,7 @@ module AsyncRequest
       update_attributes!(status: :failed, status_code: 500, response: error_response(error))
     end
 
+    # This method will return the job execution time in milliseconds
     def execution_time
       (1000 * (updated_at - created_at)).to_i
     end

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -30,7 +30,7 @@ module AsyncRequest
     end
 
     def execution_time
-      1000 * (updated_at - created_at).to_i
+      (1000 * (updated_at - created_at)).to_i
     end
 
     private


### PR DESCRIPTION
## Summary

Se agregó un logueo para indicar el tiempo de ejecución de los jobs finalizados y otro para loguear el app vesion cuando se hace polling.

Además se cambio el `id` por el `uid` en los métodos del modelo job.

## Screenshots
execution time
![image](https://github.com/widergy/async-requests/assets/88202495/95c54117-2500-46e5-9302-a2d7636266fc)
exec time and app version
![image](https://github.com/widergy/async-requests/assets/88202495/3a60c51d-845b-483f-81b8-78a659db1a74)
postman
![image](https://github.com/widergy/async-requests/assets/88202495/ee5a0a63-bf96-4d0b-9519-c4f989c5edeb)
uid when pocessing and finished successfully
![image](https://github.com/widergy/async-requests/assets/88202495/1a79976d-6706-4ff9-9ba3-fefb24742a97)
uid when failed
![image](https://github.com/widergy/async-requests/assets/88202495/3c195465-13da-4d91-9889-0c2645ed3057)

## Test Cases

N/A

## Checklist 

- [x] Verifiqué / Realicé los cambios requeridos en Active Admin, o alguna configuración adicional (en caso de corresponder) ⚙️
- [x] Verifiqué si mis cambios requieren actualizar la documentación técnica y la actualicé (en caso de corresponder). 📝
- [x] Revisé los archivos modificados antes de liberar el pull request para revisión. 👩🏻‍💻
- [x] Actualicé la card de JIRA considerando: **estado**, **horas incurridas**, **enfoque tomado como comentario de la card** y **requisitos de configuración asociados**✅
- [x] El título de mi PR sigue la convención requerida 👉 [%scope - %descripcion](https://www.conventionalcommits.org/en/v1.0.0/)

- [ ] **Post Merge** 👉 Actualicé el status de la card en JIRA.

## JIRA Card

https://widergy.atlassian.net/browse/ANA-53
