### PR TITLE
feat: [DEV-313] Add support for Rails >=7 and Sidekiq >=7

### DIFF
--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -14,7 +14,7 @@ module AsyncRequest
 
     def successfully_processed!(response, status_code)
       Rails.logger.info("Processing finished successfully for #{worker} job with id=#{uid}")
-      update_attributes!(
+      update!(
         status: :processed,
         status_code: map_status_code(status_code),
         response: response.to_json
@@ -26,7 +26,7 @@ module AsyncRequest
       Rails.logger.info(log_message)
       Rails.logger.error "#{error.inspect} \n #{error.backtrace.join("\n")}"
       Rollbar.error(error, log_message, params: filtered_params(params))
-      update_attributes!(status: :failed, status_code: 500, response: error_response(error))
+      update!(status: :failed, status_code: 500, response: error_response(error))
     end
 
     # This method will return the job execution time in milliseconds
@@ -42,9 +42,9 @@ module AsyncRequest
     end
 
     def filtered_params(params)
-      ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
-                                           .filter(params.compact)
-                                           .inspect
+      ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+                                        .filter(params.second.compact)
+                                        .inspect
     end
 
     def error_response(error)

--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -43,7 +43,7 @@ module AsyncRequest
 
     def filtered_params(params)
       ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
-                                        .filter(params.second.compact)
+                                        .filter(params.compact)
                                         .inspect
     end
 

--- a/async_request.gemspec
+++ b/async_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", ">= 4.2"
-  s.add_dependency 'sidekiq', '>= 4.0', '< 6'
+  s.add_dependency 'sidekiq', '>= 4.0', '< 8'
 
   s.add_development_dependency "pg"
   s.add_development_dependency "pry"


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/DEV-313

## Summary

Durante el desarrollo del proyecto para la capacitación inicial en RoR, se detecto una incompatibilidad de la versión mas reciente de `async-requests` con Rails 6.1 o superior y Sidekiq 7.

Con la iniciativa de actualización de librerías, se actualizo el bootstrap de nuestras API para usar Rails >=7 y Sidekiq >=7. Por lo tanto esta incompatibilidad debe ser solucionada para que las nuevas API puedan incorporar `async-requests` sin afrontar problemas.

BREAKING CHANGES:
- En Rails 6.1 y superior se deprecó el método `update_attributes!`. [LINK CON INFO](https://til.hashrocket.com/posts/qglfzr9mza-rails-61-deprecates-updateattributes#:~:text=In%20Rails%206.1%2C%20the%20update_attributes,deprecation%20finally%20makes%20it%20official.)
- En Rails 6.0 y superior se depreco `ActionDispatch::Http::ParameterFilter`. [LINK CON INFO](https://guides.rubyonrails.org/v6.0/6_0_release_notes.html#action-pack-deprecations)
- La gema limitaba en su `.gemspec` la dependencia sidekiq a versiones anteriores a 6. No se encontró un sentido para esto, así que se modificó para que soporte versiones anteriores a sidekiq 8 (aun no existe) con el fin de evitar el error que no permita instalar la gema con `bundle install` por incompatibilidad de dependencias en el proyecto.

## Screenshots

### Worker para probar en el bootstrap
![Captura de pantalla de 2023-09-01 10-40-10](https://github.com/widergy/async-requests/assets/92753204/f1332400-799e-4cc5-a700-f4b3be309e76)

### Se incluye el modulo de la gema, se llama al worker async y devuelve el job id
![Captura de pantalla de 2023-09-01 10-40-49](https://github.com/widergy/async-requests/assets/92753204/8f9175c2-5519-42d3-9568-b47a44ddd4dd)

### Sidekiq 7 con Rails 7 procesa el worker sin problemas ni errores
![Captura de pantalla de 2023-09-01 10-42-10](https://github.com/widergy/async-requests/assets/92753204/3ac4b4b2-6787-4bc2-ac54-b8614506c2db)

### El registro del Job que queda en la BD
![Captura de pantalla de 2023-09-01 10-43-17](https://github.com/widergy/async-requests/assets/92753204/e61b764f-6420-4695-89eb-a7663b955be7)

## Checklist 

- [x] Verifiqué / Realicé los cambios requeridos en Active Admin, o alguna configuración adicional (en caso de corresponder) ⚙️
- [x] Verifiqué si mis cambios requieren actualizar la documentación técnica y la actualicé (en caso de corresponder). 📝
- [x] Revisé los archivos modificados antes de liberar el pull request para revisión. 👩🏻‍💻
- [x] Actualicé la card de JIRA considerando: **estado**, **horas incurridas**, **enfoque tomado como comentario de la card** y **requisitos de configuración asociados**✅
- [x] El título de mi PR sigue la convención requerida 👉 [%scope - %descripcion](https://www.conventionalcommits.org/en/v1.0.0/)

- [ ] **Post Merge** 👉 Actualicé el status de la card en JIRA.
