### PR TITLE
feat: [ANA-109] Adding new route passing job id in query params

### DIFF
--- a/app/controllers/async_request/jobs_controller.rb
+++ b/app/controllers/async_request/jobs_controller.rb
@@ -3,7 +3,7 @@ module AsyncRequest
     before_action :log_request
 
     def show
-      job = Job.find_by(uid: params[:id])
+      job = Job.find_by(uid: params.require(:id))
       return head :not_found unless job.present?
       job.finished? ? render_finished_job(job) : render_pending(job)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 AsyncRequest::Engine.routes.draw do
   resources :jobs, only: [:show]
+  get '/jobs', to: 'jobs#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 AsyncRequest::Engine.routes.draw do
   resources :jobs, only: [:show]
-  get '/jobs', to: 'jobs#show'
+  get '/jobs(?id=:id)', to: 'jobs#show', as: 'jobs'
 end

--- a/spec/controllers/async_request/jobs_controller_spec.rb
+++ b/spec/controllers/async_request/jobs_controller_spec.rb
@@ -21,6 +21,13 @@ module AsyncRequest
         end
       end
 
+      context 'when the job id is missing' do
+        it 'returns 400' do
+          get :show, id: nil
+          expect(response.status).to eq(400)
+        end
+      end
+
       context 'when the job exists but it is in a processing status' do
         let!(:job) { FactoryGirl.create(:async_request_job, :processing) }
         it 'returns 202' do


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/ANA-109

## Summary

Se agregó un nuevo ruteo para evitar mandar la request OPTIONS cada vez que hacemos polling, estoy va a mejorar la performance de la OV.
Esto se da porque el job id es parte de la ruta haciendo que cada url sea unica, para esto dejamos la ruta como `/async_request/jobs` y por query params se manda el job id.

## Screenshots

antes:

![image](https://github.com/widergy/async-requests/assets/88202495/7e80e416-1e40-4d4d-9526-f1f70c29244a)
![image](https://github.com/widergy/async-requests/assets/88202495/5d92e522-2b22-402f-b86f-fc5b3bd67c4f)


despues:
![image](https://github.com/widergy/async-requests/assets/88202495/e9eddaa1-ddb1-4045-8620-46e13e98cd10)
![image](https://github.com/widergy/async-requests/assets/88202495/c815b991-3973-4030-b4fa-f55ceb289bb9)



## Test Cases

N/A

## Checklist 

- [x] Verifiqué / Realicé los cambios requeridos en Active Admin, o alguna configuración adicional (en caso de corresponder) ⚙️
- [x] Verifiqué si mis cambios requieren actualizar la documentación técnica y la actualicé (en caso de corresponder). 📝
- [x] Revisé los archivos modificados antes de liberar el pull request para revisión. 👩🏻‍💻
- [x] Actualicé la card de JIRA considerando: **estado**, **horas incurridas**, **enfoque tomado como comentario de la card** y **requisitos de configuración asociados**✅
- [x] El título de mi PR sigue la convención requerida 👉 [%scope - %descripcion](https://www.conventionalcommits.org/en/v1.0.0/)

- [x] **Post Merge** 👉 Actualicé el status de la card en JIRA.


